### PR TITLE
Looks styles up locally first when traversing links to parents

### DIFF
--- a/lib/csl/style.rb
+++ b/lib/csl/style.rb
@@ -145,7 +145,8 @@ module CSL
     end
 
     def load_related_style_from(uri)
-      # TODO try local first
+      Style.load(File.basename(uri))
+    rescue CSL::ParseError
       Style.load(uri)
     end
 

--- a/spec/csl/style_spec.rb
+++ b/spec/csl/style_spec.rb
@@ -98,6 +98,11 @@ module CSL
       it 'when setting an independet-parent link a style becomes dependent' do
         expect { @style.independent_parent_link = 'foo' }.to change { @style.independent? }
       end
+
+      it 'looks up independent styles parents locally first' do
+        @style.independent_parent_link = 'http://example.com/non-existent/styles/apa'
+        expect(@style.independent_parent).to eq Style.load('apa')
+      end
     end
 
     describe 'macros' do


### PR DESCRIPTION
This is important to work with dependent styles in our CSL API